### PR TITLE
Change the participant's skill level to skill level to correctly reflect the interview skill.

### DIFF
--- a/src/components/PageComponents/InterviewsComponents/InterviewInfo/InterviewInfo.jsx
+++ b/src/components/PageComponents/InterviewsComponents/InterviewInfo/InterviewInfo.jsx
@@ -17,6 +17,7 @@ const InterviewInfo = () => {
   const { data: interviewData } = useGetPassedInterviewByIdQuery({ interviewId });
 
   const {
+    masteryLevel = {},
     dateTime = new Date(),
     attendeeId = null,
     specialization = '',
@@ -47,8 +48,8 @@ const InterviewInfo = () => {
         <Typography sx={styles.interviewSpecialization} variant='h6'>
           {specialization}
         </Typography>
-        <Typography sx={styles[lvlMastery[attendeeMasteryLevel]?.toLowerCase()]} variant='subtitle2'>
-          {`Level ${lvlMastery[attendeeMasteryLevel]}`}
+        <Typography sx={styles[lvlMastery[masteryLevel]?.toLowerCase()]} variant='subtitle2'>
+          {`Level ${lvlMastery[masteryLevel]}`}
         </Typography>
       </Box>
       <Typography sx={styles.role} variant='body1'>

--- a/src/components/PageComponents/InterviewsComponents/InterviewSideBarEvent/SideBarEvent.jsx
+++ b/src/components/PageComponents/InterviewsComponents/InterviewSideBarEvent/SideBarEvent.jsx
@@ -8,7 +8,7 @@ import navigationLinks from '@router/links';
 import { styles } from './SideBarEvent.styles';
 
 const SideBarEvent = ({ event, refHandler, passedInterview }) => {
-  const { id, title, attendeeMasteryLevel, date, role, hostId, hostFirstName, hostLastName } = event;
+  const { id, title, masteryLevel, date, role, hostId, hostFirstName, hostLastName } = event;
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { interviewId } = useParams();
@@ -36,8 +36,8 @@ const SideBarEvent = ({ event, refHandler, passedInterview }) => {
           <Typography component='div' sx={styles.title} variant='h6'>
             {title}
           </Typography>
-          <Typography component='div' sx={styles[lvlMastery[attendeeMasteryLevel]]} variant='subtitle2'>
-            {lvlMastery[attendeeMasteryLevel]}
+          <Typography component='div' sx={styles[lvlMastery[masteryLevel]]} variant='subtitle2'>
+            {lvlMastery[masteryLevel]}
           </Typography>
         </Box>
         <Typography component='div' sx={styles.eventDate} variant='body2'>
@@ -61,7 +61,7 @@ SideBarEvent.propTypes = {
   event: PropTypes.shape({
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
-    attendeeMasteryLevel: PropTypes.number,
+    masteryLevel: PropTypes.number,
     date: PropTypes.string.isRequired,
     role: PropTypes.string.isRequired,
     hostId: PropTypes.number.isRequired,

--- a/src/pages/InterviewPages/SinglePassedInterviewPage/SinglePassedInterviewPage.jsx
+++ b/src/pages/InterviewPages/SinglePassedInterviewPage/SinglePassedInterviewPage.jsx
@@ -93,6 +93,7 @@ const SinglePassedInterviewPage = () => {
   });
 
   const {
+    masteryLevel = {},
     dateTime = new Date(),
     hardSkills = {},
     softSkills = {},
@@ -125,7 +126,7 @@ const SinglePassedInterviewPage = () => {
   const { firstName = '', lastName = '' } = userContacts ?? {};
   const { firstName: candidateFirstName = '', lastName: candidateLastName = '' } = candidateContacts ?? {};
   const userRole = lvlMastery[attendeeMasteryLevel] + ' ' + attendeeSpecialization;
-  const level = lvlMastery[attendeeMasteryLevel];
+  const level = lvlMastery[masteryLevel];
 
   const EmptyInterviewSvg = mode === DARK_THEME ? EmptyRequestPicDark : EmptyRequestPicLight;
 


### PR DESCRIPTION
Изначально [тикет ](https://github.com/orgs/ratifire/projects/9/views/1?pane=issue&itemId=124575913&issue=ratifire%7Cdevrate-web%7C1544)был на не правильное отображение уровня собеседования в запланированных
Это было пофикшено Ваней на бэке, но вылезло то, что в пройденных не правильно отображалось.
Поправил